### PR TITLE
Fix issues with serialising and restoring key frame snapshots

### DIFF
--- a/3escore/BaseConnection.cpp
+++ b/3escore/BaseConnection.cpp
@@ -520,7 +520,10 @@ void BaseConnection::flushCollatedPacketUnguarded()
 {
   if (_collation->collatedBytes())
   {
-    _collation->finalise();
+    if (!_collation->finalise())
+    {
+      log::error("Failed to finalise collation");
+    }
     unsigned byte_count = 0;
     const uint8_t *bytes = _collation->buffer(byte_count);
     if (bytes && byte_count)

--- a/3escore/PacketStreamReader.h
+++ b/3escore/PacketStreamReader.h
@@ -107,8 +107,10 @@ public:
   void seek(std::istream::pos_type position);
 
 private:
+  using MarkerBytes = std::array<uint8_t, sizeof(tes::kPacketMarker)>;
+
   size_t readMore(size_t more_count);
-  bool checkMarker(std::vector<uint8_t> &buffer, size_t i);
+  bool checkMarker(const std::vector<uint8_t> &buffer, size_t i);
   /// Consume the packet at the head of the buffer (if valid and able).
   void consume();
 
@@ -119,7 +121,7 @@ private:
   size_t calcExpectedSize();
 
   std::shared_ptr<std::istream> _stream;
-  std::array<uint8_t, sizeof(tes::kPacketMarker)> _marker_bytes = {};
+  MarkerBytes _marker_bytes = {};
   std::vector<uint8_t> _buffer;
   size_t _chunk_size = 1024u;
   std::istream::pos_type _current_packet_pos = {};

--- a/3escore/PacketStreamReader.h
+++ b/3escore/PacketStreamReader.h
@@ -75,6 +75,10 @@ public:
   [[nodiscard]] bool isOk() const { return _stream && (!_buffer.empty() || _stream->good()); }
 
   /// Check if the stream is at the end of file.
+  ///
+  /// Note that this may report false, and allow @c extractPacket() to return @c Status::End before
+  /// this value reports true.
+  ///
   /// @return True if at end of file.
   [[nodiscard]] bool isEof() const { return !_stream || (_buffer.empty() && _stream->eof()); }
 

--- a/3escore/shapes/MultiShape.cpp
+++ b/3escore/shapes/MultiShape.cpp
@@ -4,7 +4,8 @@
 
 namespace tes
 {
-const unsigned MultiShape::BlockCountLimitSingle = 1024u;
+constexpr unsigned MultiShape::BlockCountLimitSingle;
+constexpr unsigned MultiShape::BlockCountLimitDouble;
 
 MultiShape::~MultiShape() = default;
 
@@ -50,7 +51,7 @@ int MultiShape::writeData(PacketWriter &stream, unsigned &progress_marker) const
     return 0;
   }
 
-  DataMessage msg;
+  DataMessage msg = {};
   msg.id = data().id;
   stream.reset(routingId(), DataMessage::MessageId);
   bool ok = msg.write(stream);

--- a/3escore/shapes/MultiShape.h
+++ b/3escore/shapes/MultiShape.h
@@ -34,7 +34,9 @@ class TES_CORE_API MultiShape : public Shape
 public:
   /// Maximum number of shapes in a multi shape packet using single precision. Halve for double
   /// precision. Packet is too large otherwise.
-  static const unsigned BlockCountLimitSingle;  // = 1024u;
+  static constexpr unsigned BlockCountLimitSingle = 1024u;
+  /// As per @c BlockCountLimitSingle but for using double precision attributes.
+  static constexpr unsigned BlockCountLimitDouble = BlockCountLimitSingle / 2;
   using ShapePtr = Ptr<const Shape>;
 
   /// Create a new multi-shape with the given set of @p shapes. The @c routingId(), @c id() and @c
@@ -114,7 +116,7 @@ inline MultiShape::MultiShape(MultiShape &&other) noexcept
 
 inline unsigned MultiShape::blockCountLimit() const
 {
-  return (doublePrecision()) ? BlockCountLimitSingle / 2 : BlockCountLimitSingle;
+  return (doublePrecision()) ? BlockCountLimitDouble : BlockCountLimitSingle;
 }
 }  // namespace tes
 

--- a/3esview/3esview/data/StreamThread.cpp
+++ b/3esview/3esview/data/StreamThread.cpp
@@ -586,7 +586,7 @@ void StreamThread::skipToClosestKeyframe(FrameNumber target_frame)
 
 bool StreamThread::loadSnapshot(const std::filesystem::path &snapshot_path)
 {
-  auto stream = std::make_shared<std::ifstream>(snapshot_path.string().c_str());
+  auto stream = std::make_shared<std::ifstream>(snapshot_path.string().c_str(), std::ios::binary);
   if (!stream->is_open())
   {
     return false;
@@ -601,8 +601,11 @@ bool StreamThread::loadSnapshot(const std::filesystem::path &snapshot_path)
     auto [packet_header, status, stream_pos] = reader.extractPacket();
     if (!packet_header)
     {
-      ok = false;
-      log::warn("Failed to load snapshot packet.");
+      if (status != PacketStreamReader::Status::End)
+      {
+        ok = false;
+        log::warn("Failed to load snapshot packet.");
+      }
       continue;
     }
 

--- a/3esview/3esview/painter/ShapeCache.h
+++ b/3esview/3esview/painter/ShapeCache.h
@@ -317,6 +317,8 @@ public:
       ShapeInstance attributes;
       /// Number of child shapes this has.
       unsigned child_count = 0;
+      /// True if this is a child item.
+      bool is_child = false;
     };
 
     /// Default constructor.
@@ -331,7 +333,8 @@ public:
     {
       if (_cursor != _end)
       {
-        _view = View{ _cursor->shape_id, _cursor->current, _cursor->child_count };
+        _view =
+          View{ _cursor->shape_id, _cursor->current, _cursor->child_count, _cursor->isChild() };
       }
     }
     /// Copy constructor.
@@ -503,7 +506,7 @@ inline void ShapeCache::const_iterator::next()
   } while (_cursor != _end && (_cursor->flags & ShapeFlag::Pending) == ShapeFlag::Pending);
   if (_cursor != _end)
   {
-    _view = View{ _cursor->shape_id, _cursor->current, _cursor->child_count };
+    _view = View{ _cursor->shape_id, _cursor->current, _cursor->child_count, _cursor->isChild() };
   }
   else
   {

--- a/3esview/3rdEyeScene/UIViewer.cpp
+++ b/3esview/3rdEyeScene/UIViewer.cpp
@@ -41,6 +41,9 @@ std::vector<settings::Extension> buildExtendedSettings()
 }
 }  // namespace
 
+/// Command which toggles UI rendering.
+///
+/// See @c UIViewer::setUiEnabled()
 class ToggleUI : public command::Command
 {
 public:

--- a/utils/3esrec/Rec.cpp
+++ b/utils/3esrec/Rec.cpp
@@ -474,7 +474,7 @@ std::string TesRec::generateNewOutputFile()
     bool path_ok = _overwrite;
     if (!path_ok)
     {
-      const std::ifstream in_test(output_path.c_str());
+      const std::ifstream in_test(output_path.c_str(), std::ios::binary);
       path_ok = !in_test.is_open();
     }
 


### PR DESCRIPTION
Fix issues with serialising and restoring key frame snapshots

- Fix `PacketStreamReader` position reporting for seeking back to a packet start.
- Fix file streams being openned in binary mode.
- Fix multi-shape snapshot serialisation.
